### PR TITLE
fix: remove unnecessary console logging

### DIFF
--- a/src/openai-auth.ts
+++ b/src/openai-auth.ts
@@ -231,14 +231,12 @@ async function checkForChatGPTAtCapacity(page: Page) {
 
   try {
     res = await page.$('[role="alert"]')
-    console.log('capacity text', res)
   } catch (err) {
     // ignore errors likely due to navigation
-    console.warn(err.toString())
   }
 
   if (res) {
-    const error = new types.ChatGPTError('ChatGPT is at capacity')
+    const error = new types.ChatGPTError(`ChatGPT is at capacity: ${res}`)
     error.statusCode = 503
     throw error
   }


### PR DESCRIPTION
# Changes
- Removes unnecessary console logging in `checkForChatGPTAtCapacity()`
- puts the alert message into the error message

# Info
My rationale for doing this is that the log messages can be confused with other messages from the user's actual program, which doesn't seem necessary in the first place. The capacity text that gets logged can be returned as part of the error message (which I've changed to do so in this PR), and since we're ignoring errors in the try-catch block anyway, there's no real point in logging it either.